### PR TITLE
#162 Disabled rules that are incompatible with prettier

### DIFF
--- a/packages/stylelint-config-scss/index.mjs
+++ b/packages/stylelint-config-scss/index.mjs
@@ -21,5 +21,11 @@ export default {
      * CSS Tools
      */
     'csstools/use-nesting': 'always',
+
+    /**
+     * Incompatible with Prettier
+     */
+    'scss/operator-no-newline-after': null,
+    'scss/operator-no-newline-before': null,
   },
 };


### PR DESCRIPTION
Disabled the `scss/operator-no-newline-after` and `scss/operator-no-newline-before` rule